### PR TITLE
Add AppArmor profile to fix Brioche builds on Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,14 @@ jobs:
       - name: Setup Brioche
         uses: ./ # Uses an action in the root directory
         with:
-          version: 'v0.1.3'  # Optional, defaults to v0.1.3
+          version: 'v0.1.3' # Optional, defaults to v0.1.3
 
       - name: Verify Brioche installation
         run: |
           brioche --version
           brioche install -r hello_world
           hello-world
+
+          WATERMARK="$(date -uIs)"
+          sed -i "s/\${WATERMARK}/${WATERMARK}/g" example-project/project.bri
+          brioche build -p example-project -o output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,14 @@ on:
       - main
 
 jobs:
-  setup-brioche:
-    runs-on: ubuntu-latest
+  test-setup-brioche:
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Directory where Brioche should be installed'
     required: false
     default: '$HOME/.local/bin'
+  install-apparmor:
+    description: "Install AppArmor profile for Brioche. Defaults to 'auto'"
+    required: false
+    default: 'auto'
 runs:
   using: 'composite'
   steps:
@@ -23,3 +27,4 @@ runs:
       env:
         install_dir: ${{ inputs.install-dir }}
         version: ${{ inputs.version }}
+        install_apparmor: ${{ inputs.install-apparmor }}

--- a/apparmor.d/brioche-gh-actions.tpl
+++ b/apparmor.d/brioche-gh-actions.tpl
@@ -1,0 +1,9 @@
+abi <abi/4.0>,
+include <tunables/global>
+
+# Enable unprivileged user namespaces for Brioche. See this Ubuntu blog post
+# for more context:
+# https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+${BRIOCHE_INSTALL_PATH} flags=(default_allow) {
+  userns,
+}

--- a/example-project/brioche.lock
+++ b/example-project/brioche.lock
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "hello_world": "c3fc0c4d755cd81cda36168337912de7dbb27cb8eb1d9d11c60fff613526fb44",
+    "std": "c61485184862a8ed1ec3fc12f3a6f5ea91c32b6f450cbe81cbc596c0c7e2a06d"
+  }
+}

--- a/example-project/project.bri
+++ b/example-project/project.bri
@@ -1,0 +1,13 @@
+import * as std from "std";
+import helloWorld from "hello_world";
+
+// Replaced with a timestamp to ensure the build can't be cached
+const WATERMARK_VALUE = "${WATERMARK}";
+
+export default function () {
+  return std.runBash`
+    hello-world | tee "$BRIOCHE_OUTPUT"
+  `
+    .env({ WATERMARK_VALUE })
+    .dependencies(helloWorld());
+}

--- a/install-brioche.sh
+++ b/install-brioche.sh
@@ -5,16 +5,16 @@ set -euo pipefail
 # https://github.com/brioche-dev/brioche.dev/blob/main/public/install.sh
 
 # Validate environment variables
+if [ -z "${GITHUB_PATH:-}" -o -z "${GITHUB_ACTION_PATH:-}" ]; then
+    echo '::error::$GITHUB_PATH or $GITHUB_ACTION_PATH not set! This script should be run in GitHub Actions'
+    exit 1
+fi
 if [ -z "${HOME:-}" ]; then
     echo '::error::$HOME must be set'
     exit 1
 fi
-if [ -z "${install_dir:-}" -o -z "${version:-}" ]; then
-    echo '::error::$install_dir and $version must be set'
-    exit 1
-fi
-if [ -z "${GITHUB_PATH:-}" ]; then
-    echo '::error::$GITHUB_PATH not set! This script should be run in GitHub Actions'
+if [ -z "${install_dir:-}" -o -z "${version:-}" -o -z "${install_apparmor:-}" ]; then
+    echo '::error::$install_dir, $version, and $install_apparmor must be set'
     exit 1
 fi
 
@@ -46,7 +46,7 @@ case "$install_dir" in
         ;;
 esac
 
-# Get the URL based on the OS and architecture
+# Get the OS and architecture-specific config, such as download URL and AppArmor config
 case "$OSTYPE" in
     linux*)
         case "$(uname -m)" in
@@ -57,6 +57,32 @@ case "$OSTYPE" in
                 echo "::error::Sorry, Brioche isn't currently supported on your architecture"
                 echo "  Detected architecture: $(uname -m)"
                 exit 1
+                ;;
+        esac
+
+        case "$install_apparmor" in
+            auto)
+                # Detect if we should install an AppArmor profile. AppArmor 4.0
+                # introduced new features to restrict unprivileged user
+                # namespaces, which Ubuntu 23.10 enforces by default. The
+                # Brioche AppArmor policy is meant to lift this restriction
+                # for sandboxed builds, which we only need to do on AppArmor 4+.
+                # So, we only install the policy if AppArmor is enabled and
+                # we find the config file for AppArmor abi 4.0.
+                if type aa-enabled >/dev/null && aa-enabled -q && [ -e /etc/apparmor.d/abi/4.0 ]; then
+                    should_install_apparmor=1
+                else
+                    should_install_apparmor=
+                fi
+                ;;
+            true)
+                should_install_apparmor=1
+                ;;
+            false)
+                should_install_apparmor=
+                ;;
+            *)
+                echo "::error::Invalid value for \$install_apparmor: $install_apparmor"
                 ;;
         esac
         ;;
@@ -98,3 +124,14 @@ for new_path in "${new_paths[@]}"; do
 done
 
 echo '::endgroup'
+
+
+if [ -n "$should_install_apparmor" ]; then
+    echo "::group::Installing AppArmor config"
+
+    export BRIOCHE_INSTALL_PATH="$install_dir/brioche"
+    cat "$GITHUB_ACTION_PATH/apparmor.d/brioche-gh-actions.tpl" | envsubst | sudo tee /etc/apparmor.d/brioche-gh-actions
+    sudo apparmor_parser -r /etc/apparmor.d/brioche-gh-actions
+
+    echo "::endgroup"
+fi


### PR DESCRIPTION
This PR updates the `setup-brioche` action with a new `install-apparmor` input value, which will optionally install an AppArmor profile during setup. When set to `auto` (the default), it will try and determine if the AppArmor profile is needed.

[This Ubuntu blog post](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces) provides more context, but the TL;DR is that Ubuntu 23.10+ restricts unprivileged user namespaces by default, unless enabled with an AppArmor profile. Brioche uses unprivileged user namespaces for Linux builds currently (see brioche-dev/brioche#152). So, we need an AppArmor profile to use Brioche on Ubuntu 24.04.

To detect if we need an AppArmor profile, we check if AppArmor is enabled (with the `aa-enabled` command), then check if the file `/etc/apparmor.d/abi/4.0` exists. This file is used for the AppArmor 4.0 ABI, which is when the restricted user namespace feature was added.