### PR TITLE
Fix major version tag publishing in "Publish" GH Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,9 @@ jobs:
           echo "major-version=$major_version" | tee -a "$GITHUB_OUTPUT"
       - name: Update versions
         run: |
-          echo "Pushing tag $major_version"
-          git tag -f "$major_version"
-          git push -f origin "$major_version"
+          echo "Pushing tag v${major_version}"
+          git tag -f "v${major_version}"
+          git push -f origin "v${major_version}"
         env:
           full_version: ${{ steps.versions.outputs.full-version }}
           major_version: ${{ steps.versions.outputs.major-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup Brioche
         uses: ./ # Uses an action in the root directory
-        with:
-          version: 'v0.1.3' # Optional, defaults to v0.1.3
 
       - name: Verify Brioche installation
         run: |


### PR DESCRIPTION
This PR fixes an issue in the "Publish" GH Actions workflow that led to pushing the wrong tag for the major version. Effectively, the current version pushes e.g. the tag `1`, and this PR fixes it to push the tag `v1` as intended.