### PR TITLE
ci: add Dependabot configuration to check update for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "17:00"
+      timezone: "America/Los_Angeles"


### PR DESCRIPTION
This PR introduces a new `.github/dependabot.yml` configuration file to check updates for GitHub Actions. The configuration file is similar to the one inside the other repositories.