### PR TITLE
Add Brioche nightly support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,19 @@ on:
     branches:
       - main
 
+verify-brioche: &verify-brioche
+  name: Verify Brioche installation
+  run: |
+    brioche --version
+    brioche install -r hello_world
+    hello-world
+
+    WATERMARK="$(date -uIs)"
+    sed -i "s/\${WATERMARK}/${WATERMARK}/g" example-project/project.bri
+    brioche build -p example-project -o output
+
 jobs:
-  test-setup-brioche:
+  smoke-test-setup-brioche:
     strategy:
       matrix:
         runs-on:
@@ -23,12 +34,41 @@ jobs:
       - name: Setup Brioche
         uses: ./ # Uses an action in the root directory
 
-      - name: Verify Brioche installation
-        run: |
-          brioche --version
-          brioche install -r hello_world
-          hello-world
+      - *verify-brioche
 
-          WATERMARK="$(date -uIs)"
-          sed -i "s/\${WATERMARK}/${WATERMARK}/g" example-project/project.bri
-          brioche build -p example-project -o output
+  test-setup-brioche-channel:
+    strategy:
+      matrix:
+        channel:
+          - stable
+          - nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Brioche
+        uses: ./ # Uses an action in the root directory
+        with:
+          channel: ${{ matrix.channel }}
+
+      - *verify-brioche
+
+  # This test can only be run on Brioche nightly as for now
+  test-setup-brioche-arm64-runner:
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest-arm
+          - ubuntu-latest-arm
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Brioche
+        uses: ./ # Uses an action in the root directory
+        with:
+          channel: nightly
+
+      - *verify-brioche

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,20 @@ jobs:
           sed -i "s/\${WATERMARK}/${WATERMARK}/g" example-project/project.bri
           brioche build -p example-project -o output
 
-  test-setup-brioche-channel:
+  test-setup-brioche:
     strategy:
       matrix:
-        channel:
-          - stable
-          - nightly
-    runs-on: ubuntu-latest
+        include:
+          - runs-on: ubuntu-latest
+            channel: stable
+          - runs-on: ubuntu-latest
+            channel: nightly
+          - runs-on: ubuntu-latest-arm
+            channel: stable
+          - runs-on: ubuntu-latest-arm
+            channel: nightly
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-latest-arm' && matrix.channel == 'stable' }} # Brioche stable does not support ARM architecture
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -49,24 +56,5 @@ jobs:
         uses: ./ # Uses an action in the root directory
         with:
           channel: ${{ matrix.channel }}
-
-      - *verify-brioche
-
-  # This test can only be run on Brioche nightly as for now
-  test-setup-brioche-arm64-runner:
-    strategy:
-      matrix:
-        runs-on:
-          - ubuntu-latest-arm
-          - ubuntu-latest-arm
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Setup Brioche
-        uses: ./ # Uses an action in the root directory
-        with:
-          channel: nightly
 
       - *verify-brioche

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   smoke-test-setup-brioche:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-22.04
@@ -36,6 +37,7 @@ jobs:
 
   test-setup-brioche:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         runs-on:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-latest
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout repository
@@ -40,16 +41,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-latest
-            channel: stable
-          - runs-on: ubuntu-latest
-            channel: nightly
-          - runs-on: ubuntu-latest-arm
-            channel: stable
-          - runs-on: ubuntu-latest-arm
-            channel: nightly
+          - runs-on: ubuntu-24.04
+            version: stable
+          - runs-on: ubuntu-24.04
+            version: nightly
+          - runs-on: ubuntu-24.04-arm
+            version: stable
+          - runs-on: ubuntu-24.04-arm
+            version: nightly
     runs-on: ${{ matrix.runs-on }}
-    continue-on-error: ${{ matrix.runs-on == 'ubuntu-latest-arm' && matrix.channel == 'stable' }} # Brioche stable does not support ARM architecture
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-24.04-arm' && matrix.version == 'stable' }} # Brioche stable does not support ARM architecture
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -57,6 +58,6 @@ jobs:
       - name: Setup Brioche
         uses: ./ # Uses an action in the root directory
         with:
-          channel: ${{ matrix.channel }}
+          version: ${{ matrix.version }}
 
       - *verify-brioche

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,6 @@ on:
     branches:
       - main
 
-verify-brioche: &verify-brioche
-  name: Verify Brioche installation
-  run: |
-    brioche --version
-    brioche install -r hello_world
-    hello-world
-
-    WATERMARK="$(date -uIs)"
-    sed -i "s/\${WATERMARK}/${WATERMARK}/g" example-project/project.bri
-    brioche build -p example-project -o output
-
 jobs:
   smoke-test-setup-brioche:
     strategy:
@@ -34,7 +23,16 @@ jobs:
       - name: Setup Brioche
         uses: ./ # Uses an action in the root directory
 
-      - *verify-brioche
+      - &verify-brioche
+        name: Verify Brioche installation
+        run: |
+          brioche --version
+          brioche install -r hello_world
+          hello-world
+
+          WATERMARK="$(date -uIs)"
+          sed -i "s/\${WATERMARK}/${WATERMARK}/g" example-project/project.bri
+          brioche build -p example-project -o output
 
   test-setup-brioche-channel:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
   test-setup-brioche:
     strategy:
       fail-fast: false
+      # FIXME: to add stable on ARM architecture once a new release of Brioche is done.
+      # As for now, stable version Brioche stable does not support this architecture
       matrix:
         include:
           - runs-on: ubuntu-24.04
@@ -46,11 +48,8 @@ jobs:
           - runs-on: ubuntu-24.04
             version: nightly
           - runs-on: ubuntu-24.04-arm
-            version: stable
-          - runs-on: ubuntu-24.04-arm
             version: nightly
     runs-on: ${{ matrix.runs-on }}
-    continue-on-error: ${{ matrix.runs-on == 'ubuntu-24.04-arm' && matrix.version == 'stable' }} # Brioche stable does not support ARM architecture
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Brioche
         uses: brioche-dev/setup-brioche@v1
         with:
-          version: "v0.1.5"  # Optional, specify a version or use the default (v0.1.5)
+          version: "v0.1.5"  # Optional, specify a version or use the default (latest)
           install-dir: '/custom/install/path'  # Optional, specify a custom installation path
 
       - name: Verify Brioche installation
@@ -32,7 +32,7 @@ jobs:
 
 ## Inputs
 
-- `version`: (Optional) The version of Brioche to install. Defaults to `v0.1.5` (the latest version).
+- `version`: (Optional) The version of Brioche to install. Defaults to `latest`.
 - `channel`: (Optional) The channel to install from (stable or nightly).
 - `install-dir`: (Optional) The directory where Brioche should be installed. Defaults to `$HOME/.local/bin`.
 - `install-apparmor`: (Optional) Enable or disable installation of an AppArmor profile for Brioche. Defaults to `auto`, which will automatically install it if required (e.g. on Ubuntu 24.04).
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Brioche
         uses: brioche-dev/setup-brioche@v1
         # with:
-        #   version: "v0.1.5" # Optional
+        #   version: "latest" # Optional
         #   install-dir: "$HOME/custom/install/path" # Optional
 
       - name: Build package

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Brioche
         uses: brioche-dev/setup-brioche@v1
         with:
-          version: "v0.1.5"  # Optional, specify a version or use the default (latest)
+          version: "v0.1.5"  # Optional, specify a version or a release channel
           install-dir: '/custom/install/path'  # Optional, specify a custom installation path
 
       - name: Verify Brioche installation
@@ -32,8 +32,7 @@ jobs:
 
 ## Inputs
 
-- `version`: (Optional) The version of Brioche to install. Defaults to `latest`.
-- `channel`: (Optional) The channel to install from (stable or nightly).
+- `version`: (Optional) The version of Brioche to install. It can be either a specific version (`v0.1.5`) or a release channel (`stable`, `nightly`). Defaults to `stable`.
 - `install-dir`: (Optional) The directory where Brioche should be installed. Defaults to `$HOME/.local/bin`.
 - `install-apparmor`: (Optional) Enable or disable installation of an AppArmor profile for Brioche. Defaults to `auto`, which will automatically install it if required (e.g. on Ubuntu 24.04).
 
@@ -66,7 +65,7 @@ jobs:
       - name: Setup Brioche
         uses: brioche-dev/setup-brioche@v1
         # with:
-        #   version: "latest" # Optional
+        #   version: "stable" # Optional
         #   install-dir: "$HOME/custom/install/path" # Optional
 
       - name: Build package
@@ -85,7 +84,6 @@ This Action uses GitHub's [logging groups](https://docs.github.com/en/actions/us
 ## Troubleshooting
 
 - Ensure the version specified in the `version` input is valid and available.
-- Ensure `version` is not set when `channel=nightly` is specified.
 - If Brioche isn't recognized in your shell, make sure the install path is correctly set in your environment.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Brioche
         uses: brioche-dev/setup-brioche@v1
         with:
-          version: 'v0.1.5'  # Optional, specify a version or use the default (v0.1.5)
+          version: "v0.1.5"  # Optional, specify a version or use the default (v0.1.5)
           install-dir: '/custom/install/path'  # Optional, specify a custom installation path
 
       - name: Verify Brioche installation
@@ -33,6 +33,7 @@ jobs:
 ## Inputs
 
 - `version`: (Optional) The version of Brioche to install. Defaults to `v0.1.5` (the latest version).
+- `channel`: (Optional) The channel to install from (stable or nightly).
 - `install-dir`: (Optional) The directory where Brioche should be installed. Defaults to `$HOME/.local/bin`.
 - `install-apparmor`: (Optional) Enable or disable installation of an AppArmor profile for Brioche. Defaults to `auto`, which will automatically install it if required (e.g. on Ubuntu 24.04).
 
@@ -84,6 +85,7 @@ This Action uses GitHub's [logging groups](https://docs.github.com/en/actions/us
 ## Troubleshooting
 
 - Ensure the version specified in the `version` input is valid and available.
+- Ensure `version` is not set when `channel=nightly` is specified.
 - If Brioche isn't recognized in your shell, make sure the install path is correctly set in your environment.
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Version of Brioche to install"
     required: false
     default: "v0.1.5"
+  channel:
+    description: "Channel of Brioche to install"
+    required: false
+    default: "stable"
   install-dir:
     description: "Directory where Brioche should be installed"
     required: false
@@ -27,4 +31,5 @@ runs:
       env:
         install_dir: ${{ inputs.install-dir }}
         version: ${{ inputs.version }}
+        channel: ${{ inputs.channel }}
         install_apparmor: ${{ inputs.install-apparmor }}

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,7 @@ branding:
   icon: "box"
 inputs:
   version:
-    description: "Version of Brioche to install"
-    required: false
-    default: "latest"
-  channel:
-    description: "Channel of Brioche to install"
+    description: "Version of Brioche to install. It can be either a specific version ('v0.1.5') or a release channel ('stable', 'nightly'). Defaults to 'stable'"
     required: false
     default: "stable"
   install-dir:
@@ -31,5 +27,4 @@ runs:
       env:
         install_dir: ${{ inputs.install-dir }}
         version: ${{ inputs.version }}
-        channel: ${{ inputs.channel }}
         install_apparmor: ${{ inputs.install-apparmor }}

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   version:
     description: "Version of Brioche to install"
     required: false
-    default: "v0.1.5"
+    default: "latest"
   channel:
     description: "Channel of Brioche to install"
     required: false

--- a/example-project/brioche.lock
+++ b/example-project/brioche.lock
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "hello_world": "c3fc0c4d755cd81cda36168337912de7dbb27cb8eb1d9d11c60fff613526fb44",
-    "std": "c61485184862a8ed1ec3fc12f3a6f5ea91c32b6f450cbe81cbc596c0c7e2a06d"
+    "hello_world": "bd2d236abc26082d572f9926b6e8e003560488bdccc9f9e32a219ce384ef9d31",
+    "std": "596ad9688ab218877d5535e942e88d2b0600de02b462f1cfb9cf4aeeee8d9b33"
   }
 }

--- a/install-brioche.sh
+++ b/install-brioche.sh
@@ -76,6 +76,9 @@ install_brioche() {
                 "x86_64 nightly")
                     brioche_url="https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/x86_64-linux/brioche"
                     ;;
+                "aarch64 nightly")
+                    brioche_url="https://development-content.brioche.dev/github.com/brioche-dev/brioche/branches/main/aarch64-linux/brioche"
+                    ;;
                 *)
                     echo "::error::Sorry, Brioche isn't currently supported on your architecture"
                     echo "  Detected architecture: $(uname -m)"


### PR DESCRIPTION
This PR adds the ability to set the Brioche channel to mimic what we can already do with the official Brioche install script (which has been included in this PR: https://github.com/brioche-dev/brioche.dev/pull/49).

Only two values will be accepted:

- `stable`
- `nightly`

If `nightly` is set, it won't be possible to override the Brioche version used, thus an error will be produced if both `version` and `channel` fields are present.

Bonus point: with this PR, it'll now be possible to use this GitHub action on ARM GitHub runner when using the nightly channel !