### PR TITLE
Retry failed curl downloads

### DIFF
--- a/install-brioche.sh
+++ b/install-brioche.sh
@@ -63,7 +63,7 @@ export BRIOCHE_INSTALL_CONTEXT='github-actions'
 echo "::group::Fetching latest Brioche installer version..."
 
 # Get the current version number of the installer
-installer_version=$(curl --proto '=https' --tlsv1.2 -fL 'https://installer.brioche.dev/channels/stable/latest-version.txt')
+installer_version=$(curl --retry 5 --retry-delay 15 --retry-all-errors --proto '=https' --tlsv1.2 -fL 'https://installer.brioche.dev/channels/stable/latest-version.txt')
 echo
 echo "Latest brioche-installer version is: $installer_version"
 
@@ -77,8 +77,8 @@ trap 'rm -rf -- "$brioche_temp"' EXIT
 echo "Temporary directory created at $brioche_temp"
 
 # Download the install script and signature
-curl -o "$brioche_temp/install.sh" --proto '=https' --tlsv1.2 -fL "https://installer.brioche.dev/${installer_version}/install.sh"
-curl -o "$brioche_temp/install.sh.sig" --proto '=https' --tlsv1.2 -fL "https://installer.brioche.dev/${installer_version}/install.sh.sig"
+curl -o "$brioche_temp/install.sh" --retry 5 --retry-delay 15 --retry-all-errors --proto '=https' --tlsv1.2 -fL "https://installer.brioche.dev/${installer_version}/install.sh"
+curl -o "$brioche_temp/install.sh.sig" --retry 5 --retry-delay 15 --retry-all-errors --proto '=https' --tlsv1.2 -fL "https://installer.brioche.dev/${installer_version}/install.sh.sig"
 
 # Validate the signature
 ssh-keygen -Y verify \


### PR DESCRIPTION
Just like https://github.com/brioche-dev/brioche-installer/pull/6, this PR enables retries when calling curl to download files. See that PR for more context on the motivation behind retries.

Since this repo uses the upstream Brioche installer script directly, the installer's changes will apply to the `setup-brioche` action automatically. This PR just enables retries at the next layer down: we'll also retry downloads of the installer script itself.

Brioche and the installer scripts are served via the same infrastructure: same reverse proxy server instances, both using DigitalOcean Spaces as an S3 upstream-- although serving from different S3 buckets. So for the same reason we want to retry when installing Brioche itself, I think it'd be good to retry downloads of the installer script too.

(You could argue we should update the `curl ... | sh` snippet too-- e.g. on https://brioche.dev -- for the same reasons. However, I like that the snippet is short and pretty easy to grasp, plus it's mostly meant for manual use, so I'd prefer to keep it as-is elsewhere honestly)